### PR TITLE
Optional custom top-level domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ expect(parseDomain("www.mymachine.local",["dev","local"])).to.eql({
     tld: "local"
 });
 
+var parseDevDomain = parseDomain.applyCustomTlds(["dev","local"]);
+expect(parseDevDomain("www.mymachine.dev")).to.eql({
+    subdomain: "www",
+    domain: "mymachine",
+    tld: "dev"
+});
+
 ```
 
 <br />

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ expect(parseCustomTlds("mymachine.local")).to.eql({
     tld: "local"
 });
 
+expect(parseDomain("mymachine.local",{customTldsRegExp:/\.local$/})).to.eql({
+    subdomain: "",
+    domain: "mymachine",
+    tld: "local"
+});
+
 ```
 
 <br />

--- a/README.md
+++ b/README.md
@@ -30,13 +30,6 @@ expect(parseDomain("www.mymachine.local",["dev","local"])).to.eql({
     tld: "local"
 });
 
-var parseDevDomain = parseDomain.applyCustomTlds(["dev","local"]);
-expect(parseDevDomain("www.mymachine.dev")).to.eql({
-    subdomain: "www",
-    domain: "mymachine",
-    tld: "dev"
-});
-
 ```
 
 <br />

--- a/README.md
+++ b/README.md
@@ -1,71 +1,8 @@
 parse-domain
 ========================================================================
-**Splits an url into sub-domain, domain and top-level-domain.**
+**Splits a URL into sub-domain, domain and top-level-domain parts.**
 
-Since domains are handled differently across different countries and organizations, splitting an url into sub-domain, domain and top-level-domain is not a simple regexp. **parse-domain** uses a [large list of known tlds](https://github.com/peerigon/parse-domain/blob/master/lib/build/tld.txt) (borrowed from [http://publicsuffix.org](http://publicsuffix.org/list/effective_tld_names.dat)) to recognize different parts of the domain.
-
-```javascript
-var parseDomain = require("parse-domain");
-
-expect(parseDomain("some.subdomain.example.co.uk")).to.eql({
-    subdomain: "some.subdomain",
-    domain: "example",
-    tld: "co.uk"
-});
-
-expect(parseDomain("https://user:password@example.co.uk:8080/some/path?and&query#hash")).to.eql({
-    subdomain: "",
-    domain: "example",
-    tld: "co.uk"
-});
-
-expect(parseDomain("unknown.tld.kk")).to.equal(null);
-expect(parseDomain("invalid url")).to.equal(null);
-expect(parseDomain({})).to.equal(null);
-
-expect(parseDomain("mymachine.local")).to.eql(null);
-expect(parseDomain("mymachine.local",{customTlds:["local"]})).to.eql({
-    subdomain: "",
-    domain: "mymachine",
-    tld: "local"
-});
-expect(parseDomain("mymachine.local",{customTldsRegExp:/\.local$/})).to.eql({
-    subdomain: "",
-    domain: "mymachine",
-    tld: "local"
-});
-function parseCustomTlds(url) {
-    var options = {
-        customTlds: ["local"]
-    };
-    return parseDomain(url, options);
-}
-expect(parseCustomTlds("mymachine.local")).to.eql({
-    subdomain: "",
-    domain: "mymachine",
-    tld: "local"
-});
-
-expect(parseDomain("localhost")).to.eql(null);
-expect(parseDomain("localhost",{customTldsRegExp:/localhost|\.local/})).to.eql({
-    subdomain: "",
-    domain: "",
-    tld: "localhost"
-});
-function parseLocalDomains(url) {
-    var options = {
-        customTldsRegExp: /localhost|\.local/
-    };
-    return parseDomain(url, options);
-}
-expect(parseLocalDomains("localhost")).to.eql({
-    subdomain: "",
-    domain: "",
-    tld: "localhost"
-});
-
-
-```
+Since domains are handled differently across different countries and organizations, splitting a URL into sub-domain, domain and top-level-domain parts is not a simple regexp. **parse-domain** uses a [large list of known tlds](https://github.com/peerigon/parse-domain/blob/master/lib/build/tld.txt) (borrowed from [http://publicsuffix.org](http://publicsuffix.org/list/effective_tld_names.dat)) to recognize different parts of the domain.
 
 <br />
 
@@ -81,18 +18,95 @@ Setup
 [![browser support](https://ci.testling.com/peerigon/parse-domain.png)
 ](https://ci.testling.com/peerigon/parse-domain)
 
+```sh
+# use npm to install the parse-domain package
+npm install --save parse-domain
+```
+
+```js
+// then require as usual!
+var parseDomain = require("parse-domain");
+```
+
+<br />
+
+Usage
+------------------------------------------------------------------------
+
+```js
+// long subdomains can be handled
+expect(parseDomain("some.subdomain.example.co.uk")).to.eql({
+    subdomain: "some.subdomain",
+    domain: "example",
+    tld: "co.uk"
+});
+
+// usernames, passwords and ports are disregarded
+expect(parseDomain("https://user:password@example.co.uk:8080/some/path?and&query#hash")).to.eql({
+    subdomain: "",
+    domain: "example",
+    tld: "co.uk"
+});
+
+// non-canonical top-level domains are ignored
+expect(parseDomain("unknown.tld.kk")).to.equal(null);
+
+// invalid urls are also ignored
+expect(parseDomain("invalid url")).to.equal(null);
+expect(parseDomain({})).to.equal(null);
+
+// custom top-level domains can optionally be specified
+expect(parseDomain("mymachine.local",{customTlds:["local"]})).to.eql({
+    subdomain: "",
+    domain: "mymachine",
+    tld: "local"
+});
+
+// custom regexps can optionally be specified (instead of customTlds)
+expect(parseDomain("localhost",{customTldsRegExp:/localhost|\.local/})).to.eql({
+    subdomain: "",
+    domain: "",
+    tld: "localhost"
+});
+
+// it can sometimes be helpful to apply the customTlds argument using a helper function
+function parseLocalDomains(url) {
+    var options = {
+        customTldsRegExp: /localhost|\.local/
+    };
+    return parseDomain(url, options);
+}
+expect(parseLocalDomains("localhost")).to.eql({
+    subdomain: "",
+    domain: "",
+    tld: "localhost"
+});
+expect(parseLocalDomains("mymachine.local")).to.eql({
+    subdomain: "",
+    domain: "mymachine",
+    tld: "local"
+});
+```
+
 <br />
 
 API
 ------------------------------------------------------------------------
 
-### parseDomain(url: String): ParsedDomain|null
+### `parseDomain(url: String, options: Object): parsedDomain|null`
 
 Returns `null` if `url` has an unknown tld or if it's not a valid url.
 
-### ParsedDomain
-
+#### `options`
+```js
+{
+    customTlds: String[],
+    customTldsRegExp: RegExp
+}
 ```
+
+#### `parsedDomain`
+```js
 {
     tld: String,
     domain: String,

--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ expect(parseDomain("mymachine.local",{customTlds:["local"]})).to.eql({
     domain: "mymachine",
     tld: "local"
 });
-
+expect(parseDomain("mymachine.local",{customTldsRegExp:/\.local$/})).to.eql({
+    subdomain: "",
+    domain: "mymachine",
+    tld: "local"
+});
 function parseCustomTlds(url) {
     var options = {
         customTlds: ["local"]
@@ -42,11 +46,24 @@ expect(parseCustomTlds("mymachine.local")).to.eql({
     tld: "local"
 });
 
-expect(parseDomain("mymachine.local",{customTldsRegExp:/\.local$/})).to.eql({
+expect(parseDomain("localhost")).to.eql(null);
+expect(parseDomain("localhost",{customTldsRegExp:/localhost|\.local/})).to.eql({
     subdomain: "",
-    domain: "mymachine",
-    tld: "local"
+    domain: "",
+    tld: "localhost"
 });
+function parseLocalDomains(url) {
+    var options = {
+        customTldsRegExp: /localhost|\.local/
+    };
+    return parseDomain(url, options);
+}
+expect(parseLocalDomains("localhost")).to.eql({
+    subdomain: "",
+    domain: "",
+    tld: "localhost"
+});
+
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ expect(parseDomain("https://user:password@example.co.uk:8080/some/path?and&query
 expect(parseDomain("unknown.tld.kk")).to.equal(null);
 expect(parseDomain("invalid url")).to.equal(null);
 expect(parseDomain({})).to.equal(null);
+
+expect(parseDomain("www.mymachine.local")).to.equal(null);
+expect(parseDomain("www.mymachine.local",["dev","local"])).to.eql({
+    subdomain: "www",
+    domain: "mymachine",
+    tld: "local"
+});
+
 ```
 
 <br />

--- a/README.md
+++ b/README.md
@@ -23,9 +23,21 @@ expect(parseDomain("unknown.tld.kk")).to.equal(null);
 expect(parseDomain("invalid url")).to.equal(null);
 expect(parseDomain({})).to.equal(null);
 
-expect(parseDomain("www.mymachine.local")).to.equal(null);
-expect(parseDomain("www.mymachine.local",["dev","local"])).to.eql({
-    subdomain: "www",
+expect(parseDomain("mymachine.local")).to.eql(null);
+expect(parseDomain("mymachine.local",{customTlds:["local"]})).to.eql({
+    subdomain: "",
+    domain: "mymachine",
+    tld: "local"
+});
+
+function parseCustomTlds(url) {
+    var options = {
+        customTlds: ["local"]
+    };
+    return parseDomain(url, options);
+}
+expect(parseCustomTlds("mymachine.local")).to.eql({
+    subdomain: "",
     domain: "mymachine",
     tld: "local"
 });

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ expect(parseDomain("mymachine.local",{customTlds:["local"]})).to.eql({
 });
 
 // custom regexps can optionally be specified (instead of customTlds)
-expect(parseDomain("localhost",{customTldsRegExp:/localhost|\.local/})).to.eql({
+expect(parseDomain("localhost",{customTlds:/localhost|\.local/})).to.eql({
     subdomain: "",
     domain: "",
     tld: "localhost"
@@ -72,7 +72,7 @@ expect(parseDomain("localhost",{customTldsRegExp:/localhost|\.local/})).to.eql({
 // it can sometimes be helpful to apply the customTlds argument using a helper function
 function parseLocalDomains(url) {
     var options = {
-        customTldsRegExp: /localhost|\.local/
+        customTlds: /localhost|\.local/
     };
     return parseDomain(url, options);
 }
@@ -100,8 +100,7 @@ Returns `null` if `url` has an unknown tld or if it's not a valid url.
 #### `options`
 ```js
 {
-    customTlds: String[],
-    customTldsRegExp: RegExp
+    customTlds: RegExp|String[]
 }
 ```
 

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -76,15 +76,4 @@ function parseDomain(url, customTlds) {
     };
 }
 
-/**
- * Inject a list of custom TLDs, usually for local development purposes.
- * @param {string|array} customTlds
- * @return {Function}
- */
-parseDomain.applyCustomTlds = function (customTlds) {
-    return function partiallyAppliedParseDomain(url) {
-        return parseDomain(url, customTlds);
-    };
-};
-
 module.exports = exports = parseDomain;

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -24,18 +24,24 @@ var urlParts = /^(https?:\/\/)?(.+@)?(.+?)(:\d{2,5})?(\/.*)?$/,// 1 = protocol, 
  *
  * If the given url is not valid or isn't supported by the tld.txt, this function returns null.
  *
- * @param {string} url
- * @param {string|array} [customTlds]
+ * @param {String}   url
+ * @param {Object}   [options]
+ * @param {String[]} [options.customTlds]
  * @returns {Object|null}
  */
-function parseDomain(url, customTlds) {
+function parseDomain(url, options) {
     var urlSplit,
         tld,
         domain,
-        subdomain;
+        subdomain,
+        customTldsRegExp;
 
     if (!url || typeof url !== "string") {
         return null;
+    }
+
+    if (!options || typeof options !== "object") {
+        options = Object.create(null);
     }
 
     // urlSplit can't be null because urlParts will always match at the third capture
@@ -45,16 +51,12 @@ function parseDomain(url, customTlds) {
     // check if tld is supported
     tld = domain.match(knownTlds);
 
-    // for potentially unrecognized tlds, check if domain matches list of custom tlds
-    if (tld === null && customTlds) {
-        if (typeof customTlds === "string") {
-            // convert comma-delimited strings into arrays
-            customTlds = customTlds.split(",");
-        }
-        // convert customTlds to a regexp
-        customTlds = new RegExp("\\.("+customTlds.join("|")+")$");
+    // for potentially unrecognized tlds, try matching against custom tlds
+    if (tld === null && options.customTlds) {
+        // convert options.customTlds to a regexp
+        customTldsRegExp = new RegExp("\\.("+options.customTlds.join("|")+")$");
         // try matching against a built regexp of custom tlds
-        tld = domain.match(customTlds);
+        tld = domain.match(customTldsRegExp);
     }
 
     if (tld === null) {

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -76,4 +76,15 @@ function parseDomain(url, customTlds) {
     };
 }
 
-module.exports = parseDomain;
+/**
+ * Inject a list of custom TLDs, usually for local development purposes.
+ * @param {string|array} customTlds
+ * @return {Function}
+ */
+parseDomain.applyCustomTlds = function (customTlds) {
+    return function partiallyAppliedParseDomain(url) {
+        return parseDomain(url, customTlds);
+    };
+};
+
+module.exports = exports = parseDomain;

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -69,7 +69,10 @@ function parseDomain(url, options) {
     // remove tld and split by dot
     urlSplit = domain.slice(0, -tld.length).split(dot);
 
-    tld = tld.slice(1);   // removes the remaining dot
+    if (tld.charAt(0) === ".") {
+        // removes the remaining dot, if present (added to handle localhost)
+        tld = tld.slice(1);
+    }
     domain = urlSplit.pop();
     subdomain = urlSplit.join(".");
 

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -25,9 +25,10 @@ var urlParts = /^(https?:\/\/)?(.+@)?(.+?)(:\d{2,5})?(\/.*)?$/,// 1 = protocol, 
  * If the given url is not valid or isn't supported by the tld.txt, this function returns null.
  *
  * @param {string} url
+ * @param {string|array} [customTlds]
  * @returns {Object|null}
  */
-function parseDomain(url) {
+function parseDomain(url, customTlds) {
     var urlSplit,
         tld,
         domain,
@@ -43,6 +44,19 @@ function parseDomain(url) {
 
     // check if tld is supported
     tld = domain.match(knownTlds);
+
+    // for potentially unrecognized tlds, check if domain matches list of custom tlds
+    if (tld === null && customTlds) {
+        if (typeof customTlds === "string") {
+            // convert comma-delimited strings into arrays
+            customTlds = customTlds.split(",");
+        }
+        // convert customTlds to a regexp
+        customTlds = new RegExp("\\.("+customTlds.join("|")+")$");
+        // try matching against a built regexp of custom tlds
+        tld = domain.match(customTlds);
+    }
+
     if (tld === null) {
         return null;
     }

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -26,8 +26,7 @@ var urlParts = /^(https?:\/\/)?(.+@)?(.+?)(:\d{2,5})?(\/.*)?$/,// 1 = protocol, 
  *
  * @param {String}   url
  * @param {Object}   [options]
- * @param {String[]} [options.customTlds]
- * @param {String[]} [options.customTldsRegExp]
+ * @param {String[]|RegExp} [options.customTlds]
  * @returns {Object|null}
  */
 function parseDomain(url, options) {
@@ -52,13 +51,13 @@ function parseDomain(url, options) {
     tld = domain.match(knownTlds);
 
     // for potentially unrecognized tlds, try matching against custom tlds
-    if (tld === null && options.customTlds && !options.customTldsRegExp) {
-        // build regexp from options.customTlds
-        options.customTldsRegExp = new RegExp("\\.("+options.customTlds.join("|")+")$");
-    }
-    if (tld === null && options.customTldsRegExp) {
+    if (tld === null && options.customTlds) {
+        if (!(options.customTlds instanceof RegExp)) {
+            // build regexp from options.customTlds
+            options.customTlds = new RegExp("\\.("+options.customTlds.join("|")+")$");
+        }
         // try matching against a built regexp of custom tlds
-        tld = domain.match(options.customTldsRegExp);
+        tld = domain.match(options.customTlds);
     }
 
     if (tld === null) {

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -27,14 +27,14 @@ var urlParts = /^(https?:\/\/)?(.+@)?(.+?)(:\d{2,5})?(\/.*)?$/,// 1 = protocol, 
  * @param {String}   url
  * @param {Object}   [options]
  * @param {String[]} [options.customTlds]
+ * @param {String[]} [options.customTldsRegExp]
  * @returns {Object|null}
  */
 function parseDomain(url, options) {
     var urlSplit,
         tld,
         domain,
-        subdomain,
-        customTldsRegExp;
+        subdomain;
 
     if (!url || typeof url !== "string") {
         return null;
@@ -52,11 +52,13 @@ function parseDomain(url, options) {
     tld = domain.match(knownTlds);
 
     // for potentially unrecognized tlds, try matching against custom tlds
-    if (tld === null && options.customTlds) {
-        // convert options.customTlds to a regexp
-        customTldsRegExp = new RegExp("\\.("+options.customTlds.join("|")+")$");
+    if (tld === null && options.customTlds && !options.customTldsRegExp) {
+        // build regexp from options.customTlds
+        options.customTldsRegExp = new RegExp("\\.("+options.customTlds.join("|")+")$");
+    }
+    if (tld === null && options.customTldsRegExp) {
         // try matching against a built regexp of custom tlds
-        tld = domain.match(customTldsRegExp);
+        tld = domain.match(options.customTldsRegExp);
     }
 
     if (tld === null) {

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -141,7 +141,7 @@ describe("parseDomain(url)", function () {
 
     it("should also work with custom top-level domains (eg .local) passed as regexps", function () {
         expect(parseDomain("mymachine.local")).to.eql(null);
-        expect(parseDomain("mymachine.local",{customTldsRegExp:/\.local$/})).to.eql({
+        expect(parseDomain("mymachine.local",{customTlds:/\.local$/})).to.eql({
             subdomain: "",
             domain: "mymachine",
             tld: "local"
@@ -150,14 +150,14 @@ describe("parseDomain(url)", function () {
 
     it("should also work with custom hostnames (eg localhost) when passed as a regexp", function () {
         expect(parseDomain("localhost")).to.eql(null);
-        expect(parseDomain("localhost",{customTldsRegExp:/localhost$/})).to.eql({
+        expect(parseDomain("localhost",{customTlds:/localhost$/})).to.eql({
             subdomain: "",
             domain: "",
             tld: "localhost"
         });
         function parseLocalDomains(url) {
             var options = {
-                customTldsRegExp: /localhost|\.local/
+                customTlds: /localhost|\.local/
             };
             return parseDomain(url, options);
         }

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -125,4 +125,13 @@ describe("parseDomain(url)", function () {
         });
     });
 
+    it("should also work with custom top-level domains (eg .local) passed as regexps", function () {
+        expect(parseDomain("mymachine.local")).to.eql(null);
+        expect(parseDomain("mymachine.local",{customTldsRegExp:/\.local$/})).to.eql({
+            subdomain: "",
+            domain: "mymachine",
+            tld: "local"
+        });
+    });
+
 });

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -124,20 +124,4 @@ describe("parseDomain(url)", function () {
         });
     });
 
-    it("should also work with injected custom top-level domains (like .dev or .local)", function () {
-        expect(parseDomain("www.mymachine.local")).to.eql(null);
-        var parseDevDomain = parseDomain.applyCustomTlds(["dev","local"]);
-        expect(parseDevDomain("www.mymachine.dev")).to.eql({
-            subdomain: "www",
-            domain: "mymachine",
-            tld: "dev"
-        });
-        expect(parseDevDomain("www.mymachine.local")).to.eql({
-            subdomain: "www",
-            domain: "mymachine",
-            tld: "local"
-        });
-        expect(parseDomain("www.mymachine.test")).to.eql(null);
-    });
-
 });

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -105,20 +105,21 @@ describe("parseDomain(url)", function () {
         });
     });
 
-    it("should also work with passed-in custom top-level domains (like .dev or .local)", function () {
-        expect(parseDomain("www.mymachine.local")).to.eql(null);
-        expect(parseDomain("www.mymachine.dev","dev")).to.eql({
-            subdomain: "www",
+    it("should work with custom top-level domains (eg .local)", function () {
+        expect(parseDomain("mymachine.local")).to.eql(null);
+        expect(parseDomain("mymachine.local",{customTlds:["local"]})).to.eql({
+            subdomain: "",
             domain: "mymachine",
-            tld: "dev"
+            tld: "local"
         });
-        expect(parseDomain("www.mymachine.dev","dev,local")).to.eql({
-            subdomain: "www",
-            domain: "mymachine",
-            tld: "dev"
-        });
-        expect(parseDomain("www.mymachine.local",["dev","local"])).to.eql({
-            subdomain: "www",
+        function parseCustomTlds(url) {
+            var options = {
+                customTlds: ["local"]
+            };
+            return parseDomain(url, options);
+        }
+        expect(parseCustomTlds("mymachine.local")).to.eql({
+            subdomain: "",
             domain: "mymachine",
             tld: "local"
         });

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -134,4 +134,29 @@ describe("parseDomain(url)", function () {
         });
     });
 
+    it("should also work with custom hostnames (eg localhost) when passed as a regexp", function () {
+        expect(parseDomain("localhost")).to.eql(null);
+        expect(parseDomain("localhost",{customTldsRegExp:/localhost$/})).to.eql({
+            subdomain: "",
+            domain: "",
+            tld: "localhost"
+        });
+        function parseLocalDomains(url) {
+            var options = {
+                customTldsRegExp: /localhost|\.local/
+            };
+            return parseDomain(url, options);
+        }
+        expect(parseLocalDomains("localhost")).to.eql({
+            subdomain: "",
+            domain: "",
+            tld: "localhost"
+        });
+        expect(parseLocalDomains("mymachine.local")).to.eql({
+            subdomain: "",
+            domain: "mymachine",
+            tld: "local"
+        });
+    });
+
 });

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -152,6 +152,11 @@ describe("parseDomain(url)", function () {
             domain: "",
             tld: "localhost"
         });
+        expect(parseLocalDomains("localhost:8080")).to.eql({
+            subdomain: "",
+            domain: "",
+            tld: "localhost"
+        });
         expect(parseLocalDomains("mymachine.local")).to.eql({
             subdomain: "",
             domain: "mymachine",

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -132,15 +132,9 @@ describe("parseDomain(url)", function () {
             domain: "dev",
             tld: "local"
         });
-        function parseCustomTlds(url) {
-            var options = {
-                customTlds: ["local"]
-            };
-            return parseDomain(url, options);
-        }
-        expect(parseCustomTlds("mymachine.local")).to.eql({
+        expect(parseDomain("dev.local",{customTlds:["local"]})).to.eql({
             subdomain: "",
-            domain: "mymachine",
+            domain: "dev",
             tld: "local"
         });
     });

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -125,6 +125,26 @@ describe("parseDomain(url)", function () {
         });
     });
 
+    it("should behave itself when standard top-level domains sit atom custom top-level domains (eg .dev.local)", function () {
+        expect(parseDomain("ohno.dev.local")).to.eql(null);
+        expect(parseDomain("ohno.dev.local",{customTlds:["local"]})).to.eql({
+            subdomain: "ohno",
+            domain: "dev",
+            tld: "local"
+        });
+        function parseCustomTlds(url) {
+            var options = {
+                customTlds: ["local"]
+            };
+            return parseDomain(url, options);
+        }
+        expect(parseCustomTlds("mymachine.local")).to.eql({
+            subdomain: "",
+            domain: "mymachine",
+            tld: "local"
+        });
+    });
+
     it("should also work with custom top-level domains (eg .local) passed as regexps", function () {
         expect(parseDomain("mymachine.local")).to.eql(null);
         expect(parseDomain("mymachine.local",{customTldsRegExp:/\.local$/})).to.eql({

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -105,4 +105,23 @@ describe("parseDomain(url)", function () {
         });
     });
 
+    it("should also work with passed-in custom top-level domains (like .dev or .local)", function () {
+        expect(parseDomain("www.mymachine.local")).to.eql(null);
+        expect(parseDomain("www.mymachine.dev","dev")).to.eql({
+            subdomain: "www",
+            domain: "mymachine",
+            tld: "dev"
+        });
+        expect(parseDomain("www.mymachine.dev","dev,local")).to.eql({
+            subdomain: "www",
+            domain: "mymachine",
+            tld: "dev"
+        });
+        expect(parseDomain("www.mymachine.local",["dev","local"])).to.eql({
+            subdomain: "www",
+            domain: "mymachine",
+            tld: "local"
+        });
+    });
+
 });

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -124,4 +124,20 @@ describe("parseDomain(url)", function () {
         });
     });
 
+    it("should also work with injected custom top-level domains (like .dev or .local)", function () {
+        expect(parseDomain("www.mymachine.local")).to.eql(null);
+        var parseDevDomain = parseDomain.applyCustomTlds(["dev","local"]);
+        expect(parseDevDomain("www.mymachine.dev")).to.eql({
+            subdomain: "www",
+            domain: "mymachine",
+            tld: "dev"
+        });
+        expect(parseDevDomain("www.mymachine.local")).to.eql({
+            subdomain: "www",
+            domain: "mymachine",
+            tld: "local"
+        });
+        expect(parseDomain("www.mymachine.test")).to.eql(null);
+    });
+
 });


### PR DESCRIPTION
Hello!

I've added opt-in support for custom (non-standard) top-level domains, primarily for supporting use of parse-domains on local environments, where the TLD could feasibly be set to anything.

The aim was to implement this in a way that hopefully eases factoring between development and production builds, via the `parseDomain.applyCustomTlds()` method – it returns a function that matches the original signature of the parse-domains module, so it can feasibly be exported in a custom app-specific module and used in development builds in place of the "vanilla" version of parse-domains. 😄