### PR TITLE
Updated regex to handle querystring when / mising

### DIFF
--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var urlParts = /^(https?:\/\/)?(.+@)?(.+?)(:\d{2,5})?(\/.*)?$/,// 1 = protocol, 2 = auth, 3 = domain, 4 = port, 5 = path
+var urlParts = /^(https?:\/\/)?(.+@)?(.+?)(:\d{2,5})?([/?].*)?$/,// 1 = protocol, 2 = auth, 3 = domain, 4 = port, 5 = path
     knownTlds = require("./tld.js"),
     dot = /\./g;
 

--- a/test/parseDomain.test.js
+++ b/test/parseDomain.test.js
@@ -47,6 +47,14 @@ describe("parseDomain(url)", function () {
         });
     });
 
+    it("should remove the query string", function () {
+        expect(parseDomain("example.com?and&query")).to.eql({
+            subdomain: "",
+            domain: "example",
+            tld: "com"
+        });
+    });
+
     it("should remove the port", function () {
         expect(parseDomain("example.com:8080")).to.eql({
             subdomain: "",


### PR DESCRIPTION
This will handle the case `example.com?and&query` correctly.
Before the change, the test for this case will have failed.