### PR TITLE
Check for custom TLD before check against the list of existing TLDS

### DIFF
--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -47,9 +47,6 @@ function parseDomain(url, options) {
     urlSplit = url.toLowerCase().match(urlParts);
     domain = urlSplit[3]; // domain will now be something like sub.domain.example.com
 
-    // check if tld is supported
-    tld = domain.match(knownTlds);
-
     // for potentially unrecognized tlds, try matching against custom tlds
     if (options.customTlds) {
         if (options.customTlds instanceof RegExp === false) {

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -51,7 +51,7 @@ function parseDomain(url, options) {
     tld = domain.match(knownTlds);
 
     // for potentially unrecognized tlds, try matching against custom tlds
-    if (tld === null && options.customTlds) {
+    if (options.customTlds) {
         if (options.customTlds instanceof RegExp === false) {
             // build regexp from options.customTlds
             options.customTlds = new RegExp("\\.(" + options.customTlds.join("|") + ")$");
@@ -60,9 +60,11 @@ function parseDomain(url, options) {
         tld = domain.match(options.customTlds);
     }
 
+    // If no custom tlds, check if tld is supported
     if (tld === null) {
-        return null;
+        tld = domain.match(knownTlds);
     }
+
     tld = tld[0];
 
     // remove tld and split by dot

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -31,7 +31,7 @@ var urlParts = /^(https?:\/\/)?(.+@)?(.+?)(:\d{2,5})?(\/.*)?$/,// 1 = protocol, 
  */
 function parseDomain(url, options) {
     var urlSplit,
-        tld,
+        tld = null,
         domain,
         subdomain;
 
@@ -46,7 +46,7 @@ function parseDomain(url, options) {
     // urlSplit can't be null because urlParts will always match at the third capture
     urlSplit = url.toLowerCase().match(urlParts);
     domain = urlSplit[3]; // domain will now be something like sub.domain.example.com
-
+   
     // for potentially unrecognized tlds, try matching against custom tlds
     if (options.customTlds) {
         if (options.customTlds instanceof RegExp === false) {

--- a/lib/parseDomain.js
+++ b/lib/parseDomain.js
@@ -65,6 +65,10 @@ function parseDomain(url, options) {
         tld = domain.match(knownTlds);
     }
 
+    if (tld === null) {
+       return null;
+    }
+
     tld = tld[0];
 
     // remove tld and split by dot


### PR DESCRIPTION
That will allow to add custom TLD like `example.com`.

Fixes issue #8. 