### PR TITLE
Add Wordpress hosted blog domain as private TLD

### DIFF
--- a/lib/build/tld.txt
+++ b/lib/build/tld.txt
@@ -11871,7 +11871,7 @@ remotewd.com
 // Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
 wmflabs.org
 
-//Wordpress blogs : https://www.wordpress.com
+// Wordpress blogs : https://www.wordpress.com
 // Submitted by Michael Neth <mneth@callcap.com>
 wordpress.com
 

--- a/lib/build/tld.txt
+++ b/lib/build/tld.txt
@@ -11871,6 +11871,10 @@ remotewd.com
 // Submitted by Yuvi Panda <yuvipanda@wikimedia.org>
 wmflabs.org
 
+//Wordpress blogs : https://www.wordpress.com
+// Submitted by Michael Neth <mneth@callcap.com>
+wordpress.com
+
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com>
 yolasite.com


### PR DESCRIPTION
Many individual blogs are hosted with subdomain.wordpress.com and so those should be treated as separate domains.