### PR TITLE
Add how to import module to usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Usage
 ------------------------------------------------------------------------
 
 ```javascript
+
+// import the module
+const parseDomain = require("parse-domain");
+
 // long subdomains can be handled
 expect(parseDomain("some.subdomain.example.co.uk")).to.eql({
     subdomain: "some.subdomain",


### PR DESCRIPTION
I always wonder how to import stuff without having to guess or read the code.

Which is it?
```js
const parseDomain = require("parse-domain");
const {parseDomain} = require("parse-domain");
const parseDomain = new (require("parse-domain").AbstractDomainParserFactoryFactory)().getDefaultFactory().getFunctorInstance("org.nodejs.parsers.domain");
```

This small addition to the usage clarifies that.