### PR TITLE
build-tries: make the stuff work on Windows

### DIFF
--- a/scripts/build-tries.js
+++ b/scripts/build-tries.js
@@ -43,6 +43,13 @@ const tries = [
     },
 ];
 
+function getBin(binname) {
+    if (process.platform === 'win32') {
+        binname += '.cmd';
+    }
+    return require.resolve(`.bin/${binname}`);
+}
+
 process.stderr.write(`Downloading public suffix list from ${PUBLIC_SUFFIX_URL}... `);
 
 got(PUBLIC_SUFFIX_URL, {timeout: 60 * 1000})
@@ -74,7 +81,7 @@ got(PUBLIC_SUFFIX_URL, {timeout: 60 * 1000})
     .then(() => {
         process.stderr.write("Running sanity check... ");
 
-        childProcess.execFileSync(process.execPath, [require.resolve(".bin/jest")], {
+        childProcess.execFileSync(process.execPath, [getBin("jest")], {
             cwd: rootPath,
             encoding: "utf8",
         });

--- a/scripts/build-tries.js
+++ b/scripts/build-tries.js
@@ -84,7 +84,7 @@ got(PUBLIC_SUFFIX_URL, {timeout: 60 * 1000})
         childProcess.execFileSync(process.execPath, [getBin("jest")], {
             cwd: rootPath,
             encoding: "utf8",
-            shell: process.platform === 'win32'),
+            shell: process.platform === 'win32',
         });
 
         process.stderr.write("ok" + os.EOL);

--- a/scripts/build-tries.js
+++ b/scripts/build-tries.js
@@ -84,6 +84,7 @@ got(PUBLIC_SUFFIX_URL, {timeout: 60 * 1000})
         childProcess.execFileSync(process.execPath, [getBin("jest")], {
             cwd: rootPath,
             encoding: "utf8",
+            shell: process.platform === 'win32'),
         });
 
         process.stderr.write("ok" + os.EOL);


### PR DESCRIPTION
Node would otherwise try to run the shell script as javascript (dumb, right?)

```
Running sanity check... C:\Users\eleth\AppData\Roaming\npm\node_modules\auspice\node_modules\.bin\jest:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at wrapSafe (internal/modules/cjs/loader.js:1050:16)
    at Module._compile (internal/modules/cjs/loader.js:1098:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
    at Module.load (internal/modules/cjs/loader.js:983:32)
    at Function.Module._load (internal/modules/cjs/loader.js:891:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47
```