### PR TITLE
fix: Improve scheme support in `fromUrl`

### DIFF
--- a/src/from-url.test.ts
+++ b/src/from-url.test.ts
@@ -64,6 +64,13 @@ describe(fromUrl.name, () => {
 		expect(fromUrl("")).toBe(NO_HOSTNAME);
 	});
 
+	test("it handles different schemes", () => {
+		expect(fromUrl("android-app://com.org.example")).toBe("com.org.example");
+		expect(fromUrl("file://root/.config")).toBe("root");
+		expect(fromUrl("mailto://person@mail.com")).toBe('mail.com');
+		expect(fromUrl("coap+ws://example.com")).toBe("example.com");
+	});
+
 	test("it returns the NO_HOSTNAME symbol for invalid input types", () => {
 		/* eslint-disable @typescript-eslint/ban-ts-ignore, no-null/no-null */
 		// @ts-ignore

--- a/src/from-url.ts
+++ b/src/from-url.ts
@@ -1,4 +1,4 @@
-const urlPattern = /^[a-z]+:\/\//i;
+const urlPattern = /^[a-z][*+\-.a-z]+:\/\//i;
 
 export const NO_HOSTNAME: unique symbol = Symbol("NO_HOSTNAME");
 


### PR DESCRIPTION
URI scheme is defined in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-3.1) and allows the following characters (-+*.) and schemes such as 'android-app' and more.
A full list of IANA registered schemes can be found here: [IANA URI Schemes](https://www.iana.org/assignments/uri-schemes)

This PR fixes the urlPattern used in fromUrl function to support valid schemes.
