### PR TITLE
fix: Inline sourceContents in source maps

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "outDir": "build",
     "target": "es2015",
-    "module": "esnext"
+    "module": "esnext",
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts", "src/tests/**/*.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,11 @@
 {
   "compilerOptions": {
     "strict": true,
-    "sourceMap": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "forceConsistentCasingInFileNames": true,
-    "declaration": true
+    "forceConsistentCasingInFileNames": true
   },
   "exclude": ["build/**"]
 }


### PR DESCRIPTION
The original sources that the source map were pointing to were not included in the package build. This change inlines the sourceContents into the source map.

Fixes Error when update version (Webpack) #149