### PR TITLE
fix: Add `ParseResultIp` to `main.js` exports

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ export {
   ParseResultReserved,
   ParseResultNotListed,
   ParseResultListed,
+  ParseResultIp,
 } from "./parse-domain.js";
 export { fromUrl, NO_HOSTNAME } from "./from-url.js";
 export {


### PR DESCRIPTION
Sorry for the triviality of this. It seems you missed passing an export in your entry point