### PR TITLE
chore: Fix incorrect jsr.json

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -3,9 +3,14 @@
   "version": "0.0.0-semantically-released",
   "description": "Splits a hostname into subdomains, domain and (effective) top-level domains",
   "license": "MIT",
-  "exports": "./build/main.js",
+  "exports": "./src/main.ts",
   "publish": {
-    "include": ["build", "serialized-tries", "bin", "README.md", "LICENSE"]
+    "include": ["src", "serialized-tries", "bin", "README.md", "LICENSE"],
+    "exclude": [
+      "src/**/*.test.ts",
+      "src/**/*.test.ts.snap",
+      "src/tests/**/*.ts"
+    ]
   },
   "$schema": "https://jsr.io/schema/config-file.v1.json"
 }


### PR DESCRIPTION
JSR was reporting warnings due to unsupported JavaScript entrypoints being used without type declarations. To resolve this, the configuration was updated to use TypeScript source files directly instead of compiled JavaScript files.

- The "exports" field in jsr.json was changed from "./build/main.js" to "./src/main.ts". This ensures that the entrypoint now uses the TypeScript source file, which provides type safety and helps alleviate the warning.
- The "publish.include" array was updated to include the "src" directory instead of "build". This is part of transitioning from pre-compiled JavaScript to using source TypeScript files directly, ensuring the distribution contains TypeScript for easier maintenance and debugging.
- A "publish.exclude" entry was added for "src/**/*.test.ts" files to prevent test files from being included in the published package, streamlining the package contents and avoiding unnecessary distribution of non-application logic code.