### PR TITLE
chore: Add explicit return type annotations to fromUrl function

### DIFF
--- a/src/from-url.ts
+++ b/src/from-url.ts
@@ -4,7 +4,7 @@ const invalidIpv6Pattern =
 
 export const NO_HOSTNAME: unique symbol = Symbol("NO_HOSTNAME");
 
-export const fromUrl = (urlLike: string) => {
+export const fromUrl = (urlLike: string): string | typeof NO_HOSTNAME => {
   /* istanbul ignore next */
   if (typeof URL !== "function") {
     throw new Error(


### PR DESCRIPTION
The explicit return type for the fromUrl function was added to address the error reported by JSR: [missing-explicit-return-type].