### PR TITLE
fix: restore parse-domain-update bin dropped during template merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
       "dependencies": {
         "is-ip": "^5.0.1"
       },
+      "bin": {
+        "parse-domain-update": "dist/bin/update.js"
+      },
       "devDependencies": {
         "@djankies/vitest-mcp": "0.5.1",
         "@eslint/mcp": "0.3.9",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
     "type": "git",
     "url": "https://github.com/peerigon/parse-domain.git"
   },
+  "bin": {
+    "parse-domain-update": "./dist/bin/update.js"
+  },
   "files": [
     "dist",
     "serialized-tries",
@@ -30,6 +33,7 @@
   "type": "module",
   "sideEffects": false,
   "main": "./dist/main.js",
+  "types": "./dist/main.d.ts",
   "exports": {
     ".": "./dist/main.js"
   },


### PR DESCRIPTION
## Summary

- The template merge in e93f249 accidentally dropped the `"bin"` and `"types"` fields from `package.json`.
- This silently removed the `parse-domain-update` CLI from the published package, even though `dist/bin/update.js` is still built (`npm run build:update` runs it) and referenced in the README.
- Restores both fields so `npx parse-domain-update` works again.

Fixes #238

## Test plan

- [x] `npm run build` — builds successfully, `dist/bin/update.js` exists and runs the smoke test
- [x] `node ./dist/bin/update.js` runs and downloads/serializes the PSL as expected
- [x] `npm test` passes (suite, lint, types, format, jsr dry-run)