### PR TITLE
feat: expose bin/update script via a JSR/npm exports subpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,27 @@ The list of top-level domains is stored in a [trie](https://en.wikipedia.org/wik
 npm install parse-domain
 ```
 
+This package is also published to [JSR](https://jsr.io/@peerigon/parse-domain):
+
+```sh
+deno add jsr:@peerigon/parse-domain
+```
+
 ## Updates
 
 💡 **Please note:** [publicsuffix.org](https://publicsuffix.org/) is updated several times per month. This package comes with a prebuilt list that has been downloaded at the time of `npm publish`. In order to get an up-to-date list, you should run `npx parse-domain-update` everytime you start or build your application. This will download the latest list from `https://publicsuffix.org/list/public_suffix_list.dat`.
+
+JSR packages don't support npm-style `bin` entries, so the script is published under the `./update` export instead. The script writes to a path relative to its own location, so it only works once the package has been resolved into a local `node_modules` directory (e.g. by enabling [`nodeModulesDir`](https://docs.deno.com/runtime/fundamentals/configuration/#node-modules-dir) in `deno.json`) — running it directly off a `jsr:` specifier fails because Deno doesn't expose a local path for remote-cached modules:
+
+```jsonc
+// deno.json
+{ "nodeModulesDir": "auto" }
+```
+
+```sh
+deno add jsr:@peerigon/parse-domain
+deno run --allow-net --allow-write ./node_modules/@peerigon/parse-domain/src/bin/update.ts
+```
 
 <br />
 

--- a/jsr.json
+++ b/jsr.json
@@ -3,7 +3,10 @@
   "version": "0.0.0-semantically-released",
   "description": "Splits a hostname into subdomains, domain and (effective) top-level domains",
   "license": "MIT",
-  "exports": "./src/main.ts",
+  "exports": {
+    ".": "./src/main.ts",
+    "./update": "./src/bin/update.ts"
+  },
   "publish": {
     "include": ["src", "serialized-tries", "README.md", "LICENSE"],
     "exclude": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "main": "./dist/main.js",
   "types": "./dist/main.d.ts",
   "exports": {
-    ".": "./dist/main.js"
+    ".": "./dist/main.js",
+    "./update": "./dist/bin/update.js"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
## Summary
- Adds a `./update` exports entry in both `package.json` and `jsr.json` so the public-suffix-list update script is reachable from JSR/Deno consumers, who don't get npm-style `bin` entries.
- Documents JSR installation and how to run the update script via Deno in the README, including the `nodeModulesDir` caveat needed for the script's relative path resolution to work.

## Test plan
- [x] `npm test` (format, lint, types, unit tests, JSR dry-run publish) passes
- [x] Verified `npm run test:jsr` dry-run includes `src/bin/update.ts` under the new export